### PR TITLE
added keycloak context to redirect

### DIFF
--- a/odata-oauth-keycloak/src/main/java/org/teiid/oauth/keycloak/AuthServlet.java
+++ b/odata-oauth-keycloak/src/main/java/org/teiid/oauth/keycloak/AuthServlet.java
@@ -41,7 +41,7 @@ public class AuthServlet extends HttpServlet {
         ServletOAuthClient oAuthClient = (ServletOAuthClient) req
                 .getServletContext().getAttribute(ServletOAuthClient.class.getName());        
         if(req.getRequestURL().toString().endsWith("auth")) {
-            oAuthClient.redirectRelative("token", req, resp);
+            oAuthClient.redirectRelative("keycloak/token", req, resp);
         } else if (req.getRequestURL().toString().endsWith("token")) {
             try {
                 AccessTokenResponse token = oAuthClient.getBearerToken(req);


### PR DESCRIPTION
Moving 'auth' and 'token' contexts under 'keycloak' parent resulted in the AuthServlet not working due to invalid redirect on '/odata4/keycloak/auth' request. It was redirecting to '/odata4/token', not '/odata4/keycloak/token'.
